### PR TITLE
Release 0.8.0

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,222 @@
+language: "en-US"
+
+reviews:
+  auto_review:
+    enabled: true
+    base_branches: ["main"]
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+      - "DRAFT"
+      - "Version"
+      - "version"
+      - "Release"
+      - "release"
+
+    drafts: false
+
+
+  profile: "chill"
+  request_changes_workflow: true
+  poem: false
+  collapse_walkthrough: false
+
+  path_instructions:
+    - path: "**/*.php"
+      instructions: |
+        This is a PSR-compatible PHP client library for the Searchcraft
+        API (per the project README at
+        https://www.php-fig.org/psr/). The README explicitly commits the
+        library to remaining compatible with PSR-18 HTTP clients
+        (https://www.php-fig.org/psr/psr-18/) — users bring their own
+        PSR-18 client, and the library uses php-http/discovery to resolve
+        one. Do NOT add a hard dependency on Guzzle, Symfony HttpClient,
+        or any other concrete HTTP library in `require` or under `src/`;
+        concrete implementations belong in composer.json `suggest`.
+
+        The library accepts caller-supplied PSR-17 request/stream
+        factories (the README example passes `$requestFactory` and
+        `$streamFactory` to the constructor), and exchanges PSR-7
+        request/response objects internally. Preserve those interfaces —
+        do not downgrade any parameter or return type to a concrete
+        class.
+
+        Internal coding standard: the project pins `<rule ref="PSR12"/>`
+        in phpcs.xml.dist. Do NOT apply WordPress (WPCS), PEAR, or Squiz
+        rulesets, and do NOT add PEAR-style file/class header tags
+        (@category, @package, @author, @license, @link) — the project
+        deliberately omits them. Match the existing house style: spaces
+        not tabs, 4-space indent, LF line endings, 120-char soft wrap.
+
+        Every source file starts with `declare(strict_types=1);` after
+        the namespace line. Public methods carry PHPDoc with @param,
+        @return, and @throws tags — the client is expected to remain
+        typed end-to-end.
+
+        Autoloading: library code lives under the `Searchcraft\`
+        namespace mapped to `src/`; test code under `Searchcraft\Tests\`
+        mapped to `tests/`; test helpers under
+        `Searchcraft\Tests\Helpers` in `tests/Helpers/`. Each class must
+        live in its own file.
+
+        PHP version range is "^7.4 || ^8.0" per composer.json. Do not
+        use features that break on 7.4 (named arguments, match, readonly
+        properties, first-class callable syntax, enums) without verifying
+        compatibility.
+
+        This is a library, not a web app. Do NOT add HTML-escaping
+        helpers, session handling, CSRF protection, or any
+        framework-specific integration (WordPress, Laravel, Symfony).
+
+        Security: API keys travel in the Authorization header. Do NOT
+        log them, embed them in exception messages, include them in
+        test fixtures, or commit real keys. When JSON-encoding request
+        payloads, keep `JSON_PRESERVE_ZERO_FRACTION` — it guards
+        numeric floats like `75.00` from being coerced to ints and
+        rejected by engine-side ingest validation (see the 0.7.5 bugfix
+        in CHANGELOG.md).
+
+    - path: "src/Api/**"
+      instructions: |
+        Every API class extends `Searchcraft\Api\Base` and uses
+        `$this->request()` for standard JSON endpoints or
+        `$this->streamRequest()` for Server-Sent Events endpoints. Do
+        NOT bypass Base to call `$this->httpClient` directly — that
+        skips consistent header handling, error mapping, and JSON
+        decoding.
+
+        Endpoint methods should accept typed arguments, validate
+        pagination through `Searchcraft\Validators` helpers where
+        relevant, and return `array` (the JSON-decoded response).
+        Error responses (>= 400) are surfaced as `SearchcraftException`
+        by Base; callers should not reimplement that.
+
+    - path: "src/Api/Base.php"
+      instructions: |
+        Changes here affect every API class — verify every existing
+        endpoint test still passes. The SSE parser in
+        `parseEventStream()` must tolerate both LF and CRLF line
+        endings, ignore `:` comment lines, coalesce multi-line `data:`
+        fields with `\n`, and reassemble events split across chunk
+        boundaries. `streamRequest()` intentionally JSON-encodes the
+        body with `JSON_PRESERVE_ZERO_FRACTION` — do not remove that
+        flag. GET requests with params must include the query string
+        in the URL passed to `requestFactory->createRequest()` (this
+        was a prior bug).
+
+        All HTTP interaction must go through the PSR-18 client and
+        PSR-17 factories supplied to the constructor. Do NOT introduce
+        `curl_*`, `file_get_contents`, or any other direct transport —
+        that would break PSR-18 compatibility advertised in the README.
+
+    - path: "src/Validators.php"
+      instructions: |
+        Validators are client-side fast-fail helpers. Keep them pure
+        static functions with no I/O, no state, and no dependencies on
+        the HTTP stack. Keep the surface minimal — do not grow this
+        into a DTO or schema library. Any new validator must have a
+        matching test in `tests/ValidatorsTest.php`.
+
+    - path: "tests/**"
+      instructions: |
+        Tests use Pest + Mockery. Helper classes (test doubles, stubs,
+        concrete-subclass test rigs) live under `tests/Helpers/` with
+        the `Searchcraft\Tests\Helpers` namespace. Do NOT declare
+        helper classes inline inside a test file — one class per file,
+        autoloaded via composer's PSR-4 dev map.
+
+        Keep tests deterministic: no real network calls, no real
+        filesystem writes, no time-dependent assertions. Use Mockery
+        to mock the PSR-18 client and PSR-17 / PSR-7 interfaces.
+
+    - path: "composer.json"
+      instructions: |
+        Dependency rules, aligned with the README's PSR-compatibility
+        promise:
+        - `require`: only `php`, `ext-json`, and PSR interfaces
+          (`php-http/discovery`, `psr/http-client`). No concrete HTTP
+          client.
+        - `require-dev`: test + lint tooling only (pest, mockery,
+          php-cs-fixer, and a PSR-17/PSR-18 implementation such as
+          guzzle for the test suite).
+        - `suggest`: the concrete PSR-18 / PSR-17 implementations the
+          README recommends to end users.
+
+        The client version in `composer.json` and
+        `src/Searchcraft.php::VERSION` must stay in sync. Client semver
+        is independent of Searchcraft Engine versions (see the
+        CHANGELOG.md preamble and the Compatibility table in
+        README.md). Engine-only changes never require a client major
+        bump.
+
+    - path: "CHANGELOG.md"
+      instructions: |
+        Follow the existing layout: one H2 per version in descending
+        order, a short narrative sentence, then bulleted `New`, `Doc`,
+        and `Fix` entries. Do not prepend dates. Keep entries terse.
+        When a release adds support for new engine features, state the
+        engine version explicitly ("Support for Searchcraft Engine
+        X.Y.Z.").
+
+    - path: "README.md"
+      instructions: |
+        Keep the "Compatibility" table in sync with the latest
+        supported engine version, and keep the PSR claims honest —
+        only add a PSR reference when the library actually satisfies
+        that PSR end-to-end. Do not document unreleased methods.
+        Treat every code snippet as copy-pasteable — confirm each
+        compiles on PHP 7.4 (no match, no readonly props, etc.).
+
+    - path: "examples/**"
+      instructions: |
+        Examples are copy-paste reference material. Every example
+        must compile on PHP 7.4+, use only public API surface from
+        `src/`, and import via composer autoload. Do not reach into
+        private or protected internals, and do not hard-code real API
+        keys or URLs.
+
+    - path: "phpcs.xml.dist"
+      instructions: |
+        The project pins `<rule ref="PSR12"/>` deliberately. Do not
+        introduce PEAR, Squiz, or WordPress-Core standards, and do not
+        add file/class header sniffs that require
+        `@category`/`@package`/`@author`/`@license`/`@link` tags.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        CI should run `./vendor/bin/pest` (test suite) and a lint step
+        that invokes `phpcs` against `phpcs.xml.dist` (or
+        `php-cs-fixer fix --dry-run`). Do not skip or weaken either.
+
+  tools:
+    # Security scanning
+    semgrep:
+      enabled: true
+
+    # Secrets detection — especially important for a client that
+    # handles API keys.
+    gitleaks:
+      enabled: true
+
+  # Ignore paths
+  path_filters:
+    # Vendor dependencies
+    - "!vendor/**"
+    - "!node_modules/**"
+
+    # Build and tooling caches
+    - "!.php-cs-fixer.cache"
+    - "!.phpunit.cache/**"
+    - "!.phpunit.result.cache"
+    - "!coverage/**"
+    - "!dist/**"
+
+    # Binary assets
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!**/*.jpeg"
+    - "!**/*.gif"
+
+# Chat settings
+chat:
+  auto_reply: true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Exclude files from Packagist distribution
+/.github export-ignore
+/tests export-ignore
+phpunit.xml.dist export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 /.github export-ignore
 /tests export-ignore
 phpunit.xml.dist export-ignore
+phpcs.xml.dist export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.php-cs-fixer.cache export-ignore
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ vendor/*
 node_modules/
 dist/
 
+# php-cs-fixer local run cache
+.php-cs-fixer.cache
+
 # Compiled Java class files
 *.class
 
@@ -46,3 +49,4 @@ Thumbs.db
 *.mov
 *.wmv
 
+.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+## 0.8.0
+
+Support for Searchcraft Engine 0.10.0.
+
+- New: `Index::getCapabilities()` wraps `GET /index/:index/capabilities` and
+  returns the index's AI capability flags (`enabled`,
+  `searchSummaryConfigured`, `llmProviderConfigured`, `llmModelConfigured`).
+- New: `Search::searchSummary()` wraps `POST /index/:index/search/summary`,
+  parses the Server-Sent Events stream, and returns the tagged `metadata`,
+  `delta`, `done`, and `error` events. A callback may be supplied to react
+  to events as they arrive.
+- New: `Authentication::getIndexKeys()` wraps `GET /auth/index/:index_name`.
+- New: `Measure` API — wrapper for analytic events
+  (`trackEvent`, `trackBatch`) and dashboard reporting
+  (`getDashboardSummary`, `getDashboardConversion`, `getDashboardUsage`).
+- New: `Searchcraft\Validators` helper with `validateLimit` and
+  `validateOffset`. `Search::query`, `Search::federatedQuery`, and
+  `Search::searchSummary` now fail fast on invalid pagination before
+  issuing a request.
+- Doc: `Index::patchIndex()` docblock now notes that PATCH supports
+  top-level `ai` and `ai_enabled` updates (changing `ai_enabled` requires
+  an admin-level key).
+- Fix: `Base::request()` previously appended the query string to a local
+  variable when building GET requests but never rebuilt the PSR-7
+  request, so GET query parameters were silently dropped. The request is
+  now created once with the fully-qualified URL.
+
+## 0.7.5
+
+Initial public release of the Searchcraft PHP client. Supports Searchcraft
+Engine 0.9.x with the following API surface:
+
+- `Search` — `query()`, `federatedQuery()`.
+- `Index` — `listIndexes()`, `getIndex()`, `getIndexStats()`,
+  `createIndex()`, `updateIndex()`, `patchIndex()`, `deleteIndex()`,
+  plus document-management helpers.
+- `Documents` — bulk add/update/get/delete operations.
+- `Federation` — list/get/create/update/delete.
+- `Authentication` — per-application, per-federation, per-organization,
+  and per-key management.
+- `Healthcheck`, `Stopwords`, `Synonyms`, `Transactions`.
+- PSR-18 HTTP client / PSR-17 factory discovery with optional injection.

--- a/README.md
+++ b/README.md
@@ -403,6 +403,109 @@ $updatedFederation = $searchcraft->federation()->updateFederation('galaxy_news_f
 $result = $searchcraft->federation()->deleteFederation('old_federation');
 ```
 
+## AI Capabilities
+
+Requires Searchcraft Engine 0.10.0 or later.
+
+### Check AI Capabilities for an Index
+
+```php
+// Returns whether AI features are enabled and which pieces
+// (LLM provider, model, and search summary config) are configured.
+$capabilities = $searchcraft->index()->getCapabilities('blog');
+```
+
+### Streaming AI Search Summaries
+
+The index must have `ai_enabled: true` and a valid `ai.search_summary`
+configuration. The engine streams Server-Sent Events: one `metadata`
+event, any number of `delta` events with `content` chunks, and a final
+`done` event. `searchSummary()` returns every parsed event, and you may
+optionally pass a callback to react to events as they arrive.
+
+```php
+// Collect all events at once
+$events = $searchcraft->search()->searchSummary('blog', 'search term', [
+    'limit' => 5,
+    'mode'  => 'fuzzy',
+]);
+
+// Or stream them via a callback
+$summaryText = '';
+$searchcraft->search()->searchSummary(
+    'blog',
+    'search term',
+    ['limit' => 5],
+    function (string $event, $data) use (&$summaryText) {
+        if ($event === 'delta' && isset($data['content'])) {
+            $summaryText .= $data['content'];
+        }
+    }
+);
+```
+
+## Authentication Operations
+
+### Get Keys for an Index
+
+```php
+// Returns all authentication keys scoped to the given index.
+$keys = $searchcraft->authentication()->getIndexKeys('blog');
+```
+
+## Measure Operations
+
+The Measure API is primarily used by SDKs and CMS integrations to capture
+search usage metrics and retrieve dashboard aggregates.
+
+### Track a Single Event
+
+```php
+$searchcraft->measure()->trackEvent([
+    'event_name' => 'document_clicked',
+    'properties' => [
+        'searchcraft_index_names' => ['products'],
+        'external_document_id' => 'sku-42',
+        'document_position' => 2,
+    ],
+    'user' => [
+        'user_id'   => 'user-123',
+        'user_type' => 'authenticated',
+    ],
+]);
+```
+
+### Track a Batch of Events
+
+```php
+$searchcraft->measure()->trackBatch([
+    [
+        'event_name' => 'search_completed',
+        'properties' => ['searchcraft_index_names' => ['products']],
+        'user'       => ['user_id' => 'user-123'],
+    ],
+    // ...
+]);
+```
+
+### Dashboard Metrics
+
+```php
+// All three accept the same optional filter set: organization_id,
+// application_id, index_names, user_id, user_type, session_id,
+// event_name, date_start, date_end, granularity, rpp, page.
+$summary    = $searchcraft->measure()->getDashboardSummary(['organization_id' => '4']);
+$conversion = $searchcraft->measure()->getDashboardConversion(['date_start' => '2026-01-01']);
+$usage      = $searchcraft->measure()->getDashboardUsage(['granularity' => 'day']);
+```
+
+## Compatibility
+
+| Client version | Searchcraft Engine |
+| -------------- | ------------------ |
+| 0.8.x          | 0.10.x             |
+| 0.7.x          | 0.7.9 - 0.9.x      |
+
 ## Error Handling
 
 All operations should be wrapped in a try/catch block to handle errors:

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="searchcraft-client-php">
+    <description>
+        Coding standard for the Searchcraft PHP client. The project
+        follows PSR-12 exclusively — no PEAR-style file/class header
+        tags (@category, @package, @author, @license, @link) are
+        required. If phpcs reports MissingCategoryTag or similar, the
+        wrong --standard flag is being passed; phpcs should pick up
+        this file automatically when run from the repo root.
+    </description>
+
+    <!-- Default paths to lint when no argument is passed on the CLI. -->
+    <file>src</file>
+    <file>tests</file>
+
+    <!-- Paths to skip entirely. -->
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>tests/bootstrap.php</exclude-pattern>
+    <exclude-pattern>examples/*</exclude-pattern>
+    <exclude-pattern>demo*.php</exclude-pattern>
+
+    <rule ref="PSR12"/>
+</ruleset>

--- a/src/Api/Authentication.php
+++ b/src/Api/Authentication.php
@@ -36,6 +36,22 @@ class Authentication extends Base
     }
 
     /**
+     * Get all keys for an index.
+     *
+     * Added in Searchcraft Engine 0.10.0.
+     *
+     * @param string $indexName The index name.
+     * @return array List of authentication keys scoped to the index,
+     *               decoded from JSON.
+     * @throws SearchcraftException On network failure, an invalid JSON
+     *                              response, or an HTTP status >= 400.
+     */
+    public function getIndexKeys(string $indexName): array
+    {
+        return $this->request('GET', "/auth/index/{$indexName}");
+    }
+
+    /**
      * Get all keys for an organization.
      *
      * @param string $organizationId The organization ID

--- a/src/Api/Base.php
+++ b/src/Api/Base.php
@@ -85,6 +85,10 @@ abstract class Base
         }
 
         $url = $this->apiEndpoint . $path;
+        if ($method === 'GET' && !empty($params)) {
+            $url .= '?' . http_build_query($params);
+        }
+
         $request = $this->requestFactory->createRequest($method, $url);
 
         // Add standard headers
@@ -102,16 +106,6 @@ abstract class Base
             $request = $request->withHeader('Content-Type', 'application/json');
             $body = $this->streamFactory->createStream(json_encode($params, JSON_PRESERVE_ZERO_FRACTION));
             $request = $request->withBody($body);
-        } elseif ($method === 'GET' && !empty($params)) {
-            // Add query parameters for GET
-            $url .= '?' . http_build_query($params);
-            $request = $request->withHeader('User-Agent', 'Searchcraft-PHP-Client ' . \Searchcraft\Searchcraft::getVersion())
-                ->withHeader('Authorization', $this->apiKey)
-                ->withHeader('Accept', 'application/json');
-
-            foreach ($headers as $name => $value) {
-                $request = $request->withHeader($name, $value);
-            }
         }
 
         try {
@@ -145,5 +139,213 @@ abstract class Base
         }
 
         return $data;
+    }
+
+    /**
+     * Perform a request that returns a Server-Sent Events (SSE) stream.
+     *
+     * Each event is parsed into an associative array of
+     * `['event' => string, 'data' => mixed]`. When `$onEvent` is provided
+     * it is invoked once per event as it is read from the stream,
+     * receiving the event name and decoded data. The full list of events
+     * is returned once the stream has been fully consumed.
+     *
+     * @param string $method HTTP method to use for the request (for
+     *                       example `"GET"` or `"POST"`).
+     * @param string $path API path relative to the configured endpoint.
+     *                     A leading `/` is added automatically if absent.
+     * @param array $params Request parameters. For POST/PUT/PATCH/DELETE
+     *                      methods these are JSON-encoded and sent as the
+     *                      request body; for GET they are ignored.
+     * @param callable|null $onEvent Optional per-event callback. Signature:
+     *                               `fn(string $event, mixed $data): void`.
+     * @param array $headers Additional headers to apply to the request,
+     *                       as an associative array of `name => value`.
+     * @return array List of parsed SSE events as described above.
+     * @throws SearchcraftException On network failure, an invalid JSON
+     *                              error response, or an HTTP status >= 400.
+     */
+    protected function streamRequest(
+        string $method,
+        string $path,
+        array $params = [],
+        ?callable $onEvent = null,
+        array $headers = []
+    ): array {
+        if (substr($path, 0, 1) !== '/') {
+            $path = '/' . $path;
+        }
+
+        $url = $this->apiEndpoint . $path;
+        $request = $this->requestFactory->createRequest($method, $url);
+
+        $request = $request->withHeader('User-Agent', \Searchcraft\Searchcraft::getVersion())
+            ->withHeader('Authorization', $this->apiKey)
+            ->withHeader('Accept', 'text/event-stream');
+
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        if (in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE']) && !empty($params)) {
+            $request = $request->withHeader('Content-Type', 'application/json');
+            $body = $this->streamFactory->createStream(json_encode($params, JSON_PRESERVE_ZERO_FRACTION));
+            $request = $request->withBody($body);
+        }
+
+        try {
+            $response = $this->httpClient->sendRequest($request);
+        } catch (\Throwable $e) {
+            throw new SearchcraftException('API request failed: ' . $e->getMessage(), 0, $e);
+        }
+
+        $statusCode = $response->getStatusCode();
+        if ($statusCode >= 400) {
+            $errorBody = (string) $response->getBody();
+            $errorData = json_decode($errorBody, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $errorData = ['error' => ['message' => $errorBody ?: 'Unknown error']];
+            }
+            throw SearchcraftException::fromApiResponse($errorData, $statusCode);
+        }
+
+        return $this->parseEventStream($response->getBody(), $onEvent);
+    }
+
+    /**
+     * Parse a Server-Sent Events stream into an array of events.
+     *
+     * Expects a PSR-7 {@see \Psr\Http\Message\StreamInterface} (or any
+     * object exposing `eof()`, `read(int $length)`, and optionally
+     * `rewind()`), reads it to completion, and groups each SSE frame into
+     * an associative array keyed by `event` and `data`. When a frame's
+     * `data:` field parses as JSON the decoded value is returned;
+     * otherwise the raw string is returned as-is. Comment lines (`:`)
+     * are ignored, CRLF and LF line endings are both accepted, and
+     * events split across chunk boundaries are reassembled correctly.
+     *
+     * @param \Psr\Http\Message\StreamInterface|object $stream The stream
+     *                      to read events from.
+     * @param callable|null $onEvent Optional callback invoked once per
+     *                               event with the event name and its
+     *                               decoded data payload. Signature:
+     *                               `fn(string $event, mixed $data): void`.
+     * @return array List of parsed SSE events, each shaped as
+     *               `['event' => string, 'data' => mixed]`.
+     */
+    protected function parseEventStream($stream, ?callable $onEvent = null): array
+    {
+        $events = [];
+        $buffer = '';
+        $currentEvent = null;
+        $dataLines = [];
+
+        $processEvent = function () use (&$events, &$currentEvent, &$dataLines, $onEvent) {
+            if ($currentEvent === null && empty($dataLines)) {
+                return;
+            }
+
+            $eventName = $currentEvent ?? 'message';
+            $rawData = implode("\n", $dataLines);
+            $decoded = json_decode($rawData, true);
+            $data = (json_last_error() === JSON_ERROR_NONE) ? $decoded : $rawData;
+
+            $entry = ['event' => $eventName, 'data' => $data];
+            $events[] = $entry;
+
+            if ($onEvent !== null) {
+                $onEvent($eventName, $data);
+            }
+
+            $currentEvent = null;
+            $dataLines = [];
+        };
+
+        if (method_exists($stream, 'rewind')) {
+            try {
+                $stream->rewind();
+            } catch (\Throwable $e) {
+                // Stream may not be rewindable; continue reading from its
+                // current position.
+            }
+        }
+
+        while (!$stream->eof()) {
+            $chunk = $stream->read(8192);
+            if ($chunk === '' || $chunk === false) {
+                break;
+            }
+            $buffer .= $chunk;
+
+            while (($newlinePos = strpos($buffer, "\n")) !== false) {
+                $line = substr($buffer, 0, $newlinePos);
+                $buffer = substr($buffer, $newlinePos + 1);
+
+                if (substr($line, -1) === "\r") {
+                    $line = substr($line, 0, -1);
+                }
+
+                if ($line === '') {
+                    $processEvent();
+                    continue;
+                }
+
+                if (strpos($line, ':') === 0) {
+                    // Comment line — ignore.
+                    continue;
+                }
+
+                $colonPos = strpos($line, ':');
+                if ($colonPos === false) {
+                    $field = $line;
+                    $value = '';
+                } else {
+                    $field = substr($line, 0, $colonPos);
+                    $value = substr($line, $colonPos + 1);
+                    if (isset($value[0]) && $value[0] === ' ') {
+                        $value = substr($value, 1);
+                    }
+                }
+
+                if ($field === 'event') {
+                    $currentEvent = $value;
+                } elseif ($field === 'data') {
+                    $dataLines[] = $value;
+                }
+            }
+        }
+
+        if ($buffer !== '') {
+            // Flush any trailing line in the buffer that was not terminated
+            // with a newline.
+            $line = $buffer;
+            if (substr($line, -1) === "\r") {
+                $line = substr($line, 0, -1);
+            }
+
+            if ($line !== '' && strpos($line, ':') !== 0) {
+                $colonPos = strpos($line, ':');
+                if ($colonPos === false) {
+                    $field = $line;
+                    $value = '';
+                } else {
+                    $field = substr($line, 0, $colonPos);
+                    $value = substr($line, $colonPos + 1);
+                    if (isset($value[0]) && $value[0] === ' ') {
+                        $value = substr($value, 1);
+                    }
+                }
+
+                if ($field === 'event') {
+                    $currentEvent = $value;
+                } elseif ($field === 'data') {
+                    $dataLines[] = $value;
+                }
+            }
+        }
+
+        $processEvent();
+
+        return $events;
     }
 }

--- a/src/Api/Index.php
+++ b/src/Api/Index.php
@@ -91,7 +91,7 @@ class Index extends Base
     public function updateIndex(string $indexName, array $options): array
     {
         $params = array_merge(['name' => $indexName], $options);
-        return $this->request('PUT', "/index/{$indexName}", [ 'index' => $params ] );
+        return $this->request('PUT', "/index/{$indexName}", [ 'index' => $params ]);
     }
 
     /**

--- a/src/Api/Index.php
+++ b/src/Api/Index.php
@@ -47,6 +47,26 @@ class Index extends Base
     }
 
     /**
+     * Get AI capability and configuration status for an index.
+     *
+     * Reports whether AI features are enabled and whether an LLM provider,
+     * model, and search summary configuration are set for the index.
+     *
+     * Added in Searchcraft Engine 0.10.0.
+     *
+     * @param string $indexName Index name.
+     * @return array Capability details, decoded from JSON. The top-level
+     *               `ai` object contains `enabled`, `searchSummaryConfigured`,
+     *               `llmProviderConfigured`, and `llmModelConfigured` keys.
+     * @throws SearchcraftException On network failure, an invalid JSON
+     *                              response, or an HTTP status >= 400.
+     */
+    public function getCapabilities(string $indexName): array
+    {
+        return $this->request('GET', "/index/{$indexName}/capabilities");
+    }
+
+    /**
      * Create a new index.
      *
      * @param string $indexName Index name
@@ -79,7 +99,9 @@ class Index extends Base
      *
      * Allows partial configuration changes without re-ingesting data.
      * Updates are limited to search_fields, weight_multipliers, language,
-     * time_decay_field, auto_commit_delay and exclude_stop_words settings.
+     * time_decay_field, auto_commit_delay, exclude_stop_words, and top-level
+     * ai / ai_enabled settings. When ai is provided the stored AI config is
+     * replaced. Changing ai_enabled requires an admin-level key.
      *
      * @param string $indexName Index name
      * @param array $options Partial configuration options to update

--- a/src/Api/Measure.php
+++ b/src/Api/Measure.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Searchcraft\Api;
+
+use Searchcraft\Exception\SearchcraftException;
+
+/**
+ * Measure API for event ingestion and dashboard reporting.
+ *
+ * The ingestion endpoints (`trackEvent`, `trackBatch`) are primarily used by
+ * SDK and CMS integrations to capture search usage and document interaction
+ * events. The dashboard endpoints (`getDashboardSummary`,
+ * `getDashboardConversion`, `getDashboardUsage`) return aggregated metrics
+ * suitable for rendering analytics dashboards.
+ */
+class Measure extends Base
+{
+    /**
+     * Measure dashboard query filter keys accepted by the engine.
+     *
+     * @var string[]
+     */
+    private const DASHBOARD_FILTER_KEYS = [
+        'organization_id',
+        'application_id',
+        'index_names',
+        'user_id',
+        'user_type',
+        'session_id',
+        'event_name',
+        'date_start',
+        'date_end',
+        'granularity',
+        'rpp',
+        'page',
+    ];
+
+    /**
+     * Track a single measure event.
+     *
+     * Uses POST /measure/event. The event payload should include
+     * `event_name`, `properties`, and `user`. See the Searchcraft API docs
+     * for the exact event shape.
+     *
+     * @param array $event The measure event payload. Must be a top-level
+     *                     associative array with at least `event_name`,
+     *                     `properties`, and `user` keys.
+     * @return array Operation result from the engine, decoded from JSON.
+     * @throws SearchcraftException On network failure, an invalid JSON
+     *                              response, or an HTTP status >= 400.
+     */
+    public function trackEvent(array $event): array
+    {
+        return $this->request('POST', '/measure/event', $event);
+    }
+
+    /**
+     * Track a batch of measure events.
+     *
+     * Uses POST /measure/batch. Each entry should follow the same payload
+     * shape as {@see trackEvent}.
+     *
+     * @param array $events List of measure event payloads. Each element
+     *                      should be a top-level associative array shaped
+     *                      like a single event passed to {@see trackEvent}.
+     * @return array Operation result from the engine, decoded from JSON.
+     * @throws SearchcraftException On network failure, an invalid JSON
+     *                              response, or an HTTP status >= 400.
+     */
+    public function trackBatch(array $events): array
+    {
+        return $this->request('POST', '/measure/batch', $events);
+    }
+
+    /**
+     * Get the dashboard summary metrics.
+     *
+     * Uses GET /measure/dashboard/summary. Supply any of the supported
+     * filters as an associative array (`organization_id`, `application_id`,
+     * `index_names`, `user_id`, `user_type`, `session_id`, `event_name`,
+     * `date_start`, `date_end`, `granularity`, `rpp`, `page`). Unknown keys
+     * are dropped before the query string is built.
+     *
+     * @param array $filters Optional associative array of query filters.
+     *                       Unknown keys are dropped silently.
+     * @return array Dashboard summary data, decoded from JSON.
+     * @throws SearchcraftException On network failure, an invalid JSON
+     *                              response, or an HTTP status >= 400.
+     */
+    public function getDashboardSummary(array $filters = []): array
+    {
+        return $this->request(
+            'GET',
+            '/measure/dashboard/summary',
+            $this->filterDashboardQuery($filters)
+        );
+    }
+
+    /**
+     * Get the dashboard conversion metrics.
+     *
+     * Uses GET /measure/dashboard/conversion. Same filter surface as
+     * {@see getDashboardSummary}.
+     *
+     * @param array $filters Optional associative array of query filters.
+     *                       Unknown keys are dropped silently.
+     * @return array Dashboard conversion data, decoded from JSON.
+     * @throws SearchcraftException On network failure, an invalid JSON
+     *                              response, or an HTTP status >= 400.
+     */
+    public function getDashboardConversion(array $filters = []): array
+    {
+        return $this->request(
+            'GET',
+            '/measure/dashboard/conversion',
+            $this->filterDashboardQuery($filters)
+        );
+    }
+
+    /**
+     * Get the dashboard usage metrics.
+     *
+     * Uses GET /measure/dashboard/usage. Same filter surface as
+     * {@see getDashboardSummary}.
+     *
+     * @param array $filters Optional associative array of query filters.
+     *                       Unknown keys are dropped silently.
+     * @return array Dashboard usage data, decoded from JSON.
+     * @throws SearchcraftException On network failure, an invalid JSON
+     *                              response, or an HTTP status >= 400.
+     */
+    public function getDashboardUsage(array $filters = []): array
+    {
+        return $this->request(
+            'GET',
+            '/measure/dashboard/usage',
+            $this->filterDashboardQuery($filters)
+        );
+    }
+
+    /**
+     * Reduce a filter array to the keys the engine actually accepts.
+     *
+     * @param array $filters Raw caller-supplied filter array.
+     * @return array A new array containing only the keys listed in
+     *               {@see self::DASHBOARD_FILTER_KEYS}.
+     */
+    private function filterDashboardQuery(array $filters): array
+    {
+        return array_intersect_key(
+            $filters,
+            array_flip(self::DASHBOARD_FILTER_KEYS)
+        );
+    }
+}

--- a/src/Api/Search.php
+++ b/src/Api/Search.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Searchcraft\Api;
 
 use Searchcraft\Exception\SearchcraftException;
+use Searchcraft\Validators;
 
 /**
  * Class for interacting with the Searchcraft search endpoints.
@@ -17,7 +18,7 @@ class Search extends Base
      * @param string $indexName The name of the index to search
      * @param string|array $query The search query string or complex query object
      * @param array $options Search options including:
-     *   - limit: Maximum number of results to return (default: 20)
+     *   - limit: Maximum number of results to return (default: 20, max: 200)
      *   - offset: Number of results to skip (default: 0)
      *   - order_by: Field to order results by
      *   - sort: Sort direction "asc" or "desc" (default: "desc")
@@ -28,6 +29,7 @@ class Search extends Base
      */
     public function query(string $indexName, $query, array $options = []): array
     {
+        $this->validatePagination($options);
         $params = $this->buildSearchParams($query, $options);
 
         return $this->request('POST', "/index/{$indexName}/search", $params);
@@ -39,7 +41,7 @@ class Search extends Base
      * @param string $federationName The name of the federation to search
      * @param string|array $query The search query string or complex query object
      * @param array $options Search options including:
-     *   - limit: Maximum number of results to return (default: 20)
+     *   - limit: Maximum number of results to return (default: 20, max: 200)
      *   - offset: Number of results to skip (default: 0)
      *   - order_by: Field to order results by
      *   - sort: Sort direction "asc" or "desc" (default: "desc")
@@ -50,9 +52,79 @@ class Search extends Base
      */
     public function federatedQuery(string $federationName, $query, array $options = []): array
     {
+        $this->validatePagination($options);
         $params = $this->buildSearchParams($query, $options);
 
         return $this->request('POST', "/federation/{$federationName}/search", $params);
+    }
+
+    /**
+     * Request a streaming AI-generated summary for search results on an index.
+     *
+     * The engine streams Server-Sent Events (SSE) — an initial `metadata`
+     * event with `results_count` and `cached` flags, zero or more `delta`
+     * events each containing a `content` chunk of the summary text, and a
+     * final `done` event. When the generator errors an `error` event is
+     * emitted instead. The index must have `ai_enabled: true` and an
+     * AI configuration with a configured `search_summary` section.
+     *
+     * Added in Searchcraft Engine 0.10.0.
+     *
+     * @param string $indexName The name of the index to summarize.
+     * @param string|array $query The search query string or a complex query
+     *                            object. Strings are wrapped in a
+     *                            `fuzzy` / `exact` term per
+     *                            `$options['mode']`; arrays are forwarded
+     *                            to the engine verbatim.
+     * @param array $options Same options as {@see self::query} plus any
+     *                       additional payload fields. Unknown keys are
+     *                       forwarded to the engine.
+     * @param callable|null $onEvent Optional callback invoked for each SSE
+     *                               event as it is received. Signature:
+     *                               `fn(string $event, mixed $data): void`.
+     * @return array List of parsed SSE events. Each event is shaped as
+     *               `['event' => string, 'data' => mixed]`, where `data`
+     *               is JSON-decoded when the SSE `data:` field parses as
+     *               JSON and the raw string otherwise.
+     * @throws SearchcraftException When pagination is invalid, on network
+     *                              failure, or on an HTTP status >= 400.
+     */
+    public function searchSummary(
+        string $indexName,
+        $query,
+        array $options = [],
+        ?callable $onEvent = null
+    ): array {
+        $this->validatePagination($options);
+        $params = $this->buildSearchParams($query, $options);
+
+        return $this->streamRequest(
+            'POST',
+            "/index/{$indexName}/search/summary",
+            $params,
+            $onEvent
+        );
+    }
+
+    /**
+     * Validate pagination options (limit and offset) when supplied.
+     *
+     * @param array $options The caller-supplied search options array. Only
+     *                       the `limit` and `offset` keys are inspected;
+     *                       other keys are ignored.
+     * @return void
+     * @throws SearchcraftException When `limit` or `offset` is present but
+     *                              fails its corresponding validator.
+     */
+    private function validatePagination(array $options): void
+    {
+        if (isset($options['limit'])) {
+            Validators::validateLimit($options['limit']);
+        }
+
+        if (isset($options['offset'])) {
+            Validators::validateOffset($options['offset']);
+        }
     }
 
     /**

--- a/src/Searchcraft.php
+++ b/src/Searchcraft.php
@@ -15,6 +15,7 @@ use Searchcraft\Api\Documents;
 use Searchcraft\Api\Federation;
 use Searchcraft\Api\Healthcheck;
 use Searchcraft\Api\Index;
+use Searchcraft\Api\Measure;
 use Searchcraft\Api\Search;
 use Searchcraft\Api\Stopwords;
 use Searchcraft\Api\Synonyms;
@@ -22,7 +23,7 @@ use Searchcraft\Api\Transactions;
 
 class Searchcraft
 {
-    public const VERSION = '0.7.5';
+    public const VERSION = '0.8.0';
     public const DEFAULT_API_ENDPOINT = 'http://localhost:8000';
 
     // API Key types
@@ -190,6 +191,24 @@ class Searchcraft
     {
 
         return new Index(
+            $this->apiKey,
+            $this->apiEndpoint,
+            $this->httpClient,
+            $this->requestFactory,
+            $this->streamFactory,
+            $this->keyType
+        );
+    }
+
+    /**
+     * Measure operations for event ingestion and dashboard reporting.
+     *
+     * @return Measure
+     * @throws SearchcraftException
+     */
+    public function measure(): Measure
+    {
+        return new Measure(
             $this->apiKey,
             $this->apiEndpoint,
             $this->httpClient,

--- a/src/Searchcraft.php
+++ b/src/Searchcraft.php
@@ -291,5 +291,4 @@ class Searchcraft
             $this->keyType
         );
     }
-
 }

--- a/src/Validators.php
+++ b/src/Validators.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Searchcraft;
+
+use Searchcraft\Exception\SearchcraftException;
+
+/**
+ * Lightweight input validators for search and measure request parameters.
+ *
+ * These helpers produce fast, client-side failures so callers see typed
+ * errors before a network round-trip. They mirror the validation surface of
+ * the official TypeScript client so the two stay in lock-step.
+ */
+final class Validators
+{
+    /**
+     * Maximum search `limit` allowed by the engine.
+     *
+     * Requests above this value are rejected client-side to avoid a wasted
+     * round-trip; the engine would otherwise cap the result set to this
+     * number per its `max_result_limit` configuration.
+     *
+     * @var int
+     */
+    public const MAX_SEARCH_LIMIT = 200;
+
+    /**
+     * Ensure a search `limit` is a positive integer no greater than 200.
+     *
+     * @param mixed $limit The limit value to validate. Only positive `int`
+     *                     values up to {@see self::MAX_SEARCH_LIMIT} are
+     *                     accepted; anything else raises a
+     *                     {@see SearchcraftException}.
+     *
+     * @return void
+     * @throws SearchcraftException When the value is not a positive integer
+     *                              or exceeds the engine-side cap.
+     */
+    public static function validateLimit($limit): void
+    {
+        if (!is_int($limit) || $limit <= 0) {
+            throw new SearchcraftException('limit must be a positive integer');
+        }
+
+        if ($limit > self::MAX_SEARCH_LIMIT) {
+            throw new SearchcraftException(
+                'limit cannot exceed ' . self::MAX_SEARCH_LIMIT
+            );
+        }
+    }
+
+    /**
+     * Ensure a search `offset` is a non-negative integer.
+     *
+     * @param mixed $offset The offset value to validate. Must be an `int`
+     *                      of zero or greater; any other value raises a
+     *                      {@see SearchcraftException}.
+     *
+     * @return void
+     * @throws SearchcraftException When the value is not a non-negative
+     *                              integer.
+     */
+    public static function validateOffset($offset): void
+    {
+        if (!is_int($offset) || $offset < 0) {
+            throw new SearchcraftException('offset must be a non-negative integer');
+        }
+    }
+}

--- a/tests/Api/AuthenticationTest.php
+++ b/tests/Api/AuthenticationTest.php
@@ -101,6 +101,41 @@ test('Authentication::getFederationKeys', function () {
     expect($result)->toBe($responseData);
 });
 
+test('Authentication::getIndexKeys', function () {
+    $indexName = 'products';
+    $responseData = ['keys' => []];
+    $responseJson = json_encode($responseData);
+
+    $this->requestFactory->shouldReceive('createRequest')
+        ->once()
+        ->with('GET', $this->apiEndpoint . "/auth/index/{$indexName}")
+        ->andReturn($this->request);
+
+    $this->request->shouldReceive('withHeader')
+        ->andReturn($this->request);
+
+    $this->httpClient->shouldReceive('sendRequest')
+        ->once()
+        ->with($this->request)
+        ->andReturn($this->response);
+
+    $this->response->shouldReceive('getBody')
+        ->once()
+        ->andReturn($this->stream);
+
+    $this->response->shouldReceive('getStatusCode')
+        ->once()
+        ->andReturn(200);
+
+    $this->stream->shouldReceive('__toString')
+        ->once()
+        ->andReturn($responseJson);
+
+    $result = $this->auth->getIndexKeys($indexName);
+
+    expect($result)->toBe($responseData);
+});
+
 test('Authentication::getOrganizationKeys', function () {
     $organizationId = 'org123';
     $responseData = ['keys' => []];

--- a/tests/Api/BaseTest.php
+++ b/tests/Api/BaseTest.php
@@ -16,6 +16,48 @@ class TestApi extends Base
     {
         return $this->request($method, $path, $params, $headers);
     }
+
+    public function testParseEventStream($stream, ?callable $onEvent = null): array
+    {
+        return $this->parseEventStream($stream, $onEvent);
+    }
+}
+
+/**
+ * Minimal in-memory StreamInterface-ish stub that yields chunks from a list.
+ *
+ * Only implements the handful of methods parseEventStream calls:
+ * rewind(), eof(), read().
+ */
+class ChunkedStreamStub
+{
+    /** @var string[] */
+    private $chunks;
+    /** @var int */
+    private $cursor = 0;
+
+    public function __construct(array $chunks)
+    {
+        $this->chunks = array_values($chunks);
+    }
+
+    public function rewind(): void
+    {
+        $this->cursor = 0;
+    }
+
+    public function eof(): bool
+    {
+        return $this->cursor >= count($this->chunks);
+    }
+
+    public function read($_length): string
+    {
+        if ($this->eof()) {
+            return '';
+        }
+        return $this->chunks[$this->cursor++];
+    }
 }
 
 beforeEach(function () {
@@ -192,6 +234,100 @@ test('Base handles invalid JSON responses', function () {
 
     expect(fn() => $this->api->testRequest('GET', $path))
         ->toThrow(SearchcraftException::class, 'Invalid JSON response from API');
+});
+
+test('Base::parseEventStream parses a single event with JSON data', function () {
+    $stream = new ChunkedStreamStub([
+        "event: delta\ndata: {\"content\":\"hi\"}\n\n",
+    ]);
+
+    $events = $this->api->testParseEventStream($stream);
+
+    expect($events)->toBe([
+        ['event' => 'delta', 'data' => ['content' => 'hi']],
+    ]);
+});
+
+test('Base::parseEventStream handles CRLF line endings', function () {
+    $stream = new ChunkedStreamStub([
+        "event: delta\r\ndata: ok\r\n\r\n",
+    ]);
+
+    $events = $this->api->testParseEventStream($stream);
+
+    expect($events)->toBe([
+        ['event' => 'delta', 'data' => 'ok'],
+    ]);
+});
+
+test('Base::parseEventStream coalesces multi-line data fields with \\n', function () {
+    $stream = new ChunkedStreamStub([
+        "event: msg\ndata: line1\ndata: line2\n\n",
+    ]);
+
+    $events = $this->api->testParseEventStream($stream);
+
+    expect($events)->toBe([
+        ['event' => 'msg', 'data' => "line1\nline2"],
+    ]);
+});
+
+test('Base::parseEventStream reassembles events split across chunk boundaries', function () {
+    $stream = new ChunkedStreamStub([
+        "event: delta\nda",
+        "ta: hel",
+        "lo\n\nevent: done\ndata: {\"n\":1}\n\n",
+    ]);
+
+    $events = $this->api->testParseEventStream($stream);
+
+    expect($events)->toBe([
+        ['event' => 'delta', 'data' => 'hello'],
+        ['event' => 'done', 'data' => ['n' => 1]],
+    ]);
+});
+
+test('Base::parseEventStream ignores comment lines starting with colon', function () {
+    $stream = new ChunkedStreamStub([
+        ": keep-alive\nevent: delta\ndata: ok\n\n",
+    ]);
+
+    $events = $this->api->testParseEventStream($stream);
+
+    expect($events)->toBe([
+        ['event' => 'delta', 'data' => 'ok'],
+    ]);
+});
+
+test('Base::parseEventStream invokes per-event callback as events arrive', function () {
+    $stream = new ChunkedStreamStub([
+        "event: metadata\ndata: {\"results_count\":1}\n\n",
+        "event: delta\ndata: {\"content\":\"hi\"}\n\n",
+        "event: done\ndata: {\"results_count\":1}\n\n",
+    ]);
+
+    $captured = [];
+    $this->api->testParseEventStream($stream, function (string $event, $data) use (&$captured) {
+        $captured[] = [$event, $data];
+    });
+
+    expect($captured)->toBe([
+        ['metadata', ['results_count' => 1]],
+        ['delta', ['content' => 'hi']],
+        ['done', ['results_count' => 1]],
+    ]);
+});
+
+test('Base::parseEventStream defaults event name to "message" when absent', function () {
+    $stream = new ChunkedStreamStub([
+        "data: hello\n\n",
+    ]);
+
+    $events = $this->api->testParseEventStream($stream);
+
+    expect($events)->toBe([
+        ['event' => 'message', 'data' => 'hello'],
+    ]);
 });
 
 test('Base handles request exceptions', function () {

--- a/tests/Api/BaseTest.php
+++ b/tests/Api/BaseTest.php
@@ -6,59 +6,9 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use Searchcraft\Api\Base;
 use Searchcraft\Exception\SearchcraftException;
-
-// Create a concrete implementation of the abstract Base class for testing
-class TestApi extends Base
-{
-    public function testRequest(string $method, string $path, array $params = [], array $headers = []): array
-    {
-        return $this->request($method, $path, $params, $headers);
-    }
-
-    public function testParseEventStream($stream, ?callable $onEvent = null): array
-    {
-        return $this->parseEventStream($stream, $onEvent);
-    }
-}
-
-/**
- * Minimal in-memory StreamInterface-ish stub that yields chunks from a list.
- *
- * Only implements the handful of methods parseEventStream calls:
- * rewind(), eof(), read().
- */
-class ChunkedStreamStub
-{
-    /** @var string[] */
-    private $chunks;
-    /** @var int */
-    private $cursor = 0;
-
-    public function __construct(array $chunks)
-    {
-        $this->chunks = array_values($chunks);
-    }
-
-    public function rewind(): void
-    {
-        $this->cursor = 0;
-    }
-
-    public function eof(): bool
-    {
-        return $this->cursor >= count($this->chunks);
-    }
-
-    public function read($_length): string
-    {
-        if ($this->eof()) {
-            return '';
-        }
-        return $this->chunks[$this->cursor++];
-    }
-}
+use Searchcraft\Tests\Helpers\ChunkedStreamStub;
+use Searchcraft\Tests\Helpers\TestApi;
 
 beforeEach(function () {
     $this->apiKey = 'test-api-key';

--- a/tests/Api/DocumentsTest.php
+++ b/tests/Api/DocumentsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;

--- a/tests/Api/FederationTest.php
+++ b/tests/Api/FederationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -265,4 +266,3 @@ test('Federation::deleteFederation', function () {
 
     expect($result)->toBe($responseData);
 });
-

--- a/tests/Api/HealthcheckTest.php
+++ b/tests/Api/HealthcheckTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;

--- a/tests/Api/IndexTest.php
+++ b/tests/Api/IndexTest.php
@@ -134,6 +134,48 @@ test('Index::getIndexStats', function () {
     expect($result)->toBe($responseData);
 });
 
+test('Index::getCapabilities', function () {
+    $indexName = 'test-index';
+    $responseData = [
+        'ai' => [
+            'enabled' => true,
+            'searchSummaryConfigured' => true,
+            'llmProviderConfigured' => true,
+            'llmModelConfigured' => true,
+        ],
+    ];
+    $responseJson = json_encode($responseData);
+
+    $this->requestFactory->shouldReceive('createRequest')
+        ->once()
+        ->with('GET', $this->apiEndpoint . "/index/{$indexName}/capabilities")
+        ->andReturn($this->request);
+
+    $this->request->shouldReceive('withHeader')
+        ->andReturn($this->request);
+
+    $this->httpClient->shouldReceive('sendRequest')
+        ->once()
+        ->with($this->request)
+        ->andReturn($this->response);
+
+    $this->response->shouldReceive('getBody')
+        ->once()
+        ->andReturn($this->stream);
+
+    $this->response->shouldReceive('getStatusCode')
+        ->once()
+        ->andReturn(200);
+
+    $this->stream->shouldReceive('__toString')
+        ->once()
+        ->andReturn($responseJson);
+
+    $result = $this->index->getCapabilities($indexName);
+
+    expect($result)->toBe($responseData);
+});
+
 test('Index::createIndex', function () {
     $indexName = 'new-index';
     $options = [

--- a/tests/Api/IndexTest.php
+++ b/tests/Api/IndexTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;

--- a/tests/Api/MeasureTest.php
+++ b/tests/Api/MeasureTest.php
@@ -1,0 +1,190 @@
+<?php
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Searchcraft\Api\Measure;
+
+beforeEach(function () {
+    $this->apiKey = 'test-api-key';
+    $this->apiEndpoint = 'http://test-api-endpoint.com';
+    $this->httpClient = Mockery::mock(ClientInterface::class);
+    $this->requestFactory = Mockery::mock(RequestFactoryInterface::class);
+    $this->streamFactory = Mockery::mock(StreamFactoryInterface::class);
+    $this->request = Mockery::mock(RequestInterface::class);
+    $this->response = Mockery::mock(ResponseInterface::class);
+    $this->stream = Mockery::mock(StreamInterface::class);
+
+    $this->measure = new Measure(
+        $this->apiKey,
+        $this->apiEndpoint,
+        $this->httpClient,
+        $this->requestFactory,
+        $this->streamFactory
+    );
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+test('Measure::trackEvent posts to /measure/event', function () {
+    $event = [
+        'event_name' => 'document_clicked',
+        'properties' => [
+            'searchcraft_index_names' => ['products'],
+            'external_document_id' => 'abc-123',
+            'document_position' => 2,
+        ],
+        'user' => [
+            'user_id' => 'user-1',
+            'user_type' => 'anonymous',
+        ],
+    ];
+
+    $responseJson = json_encode(['status' => 'ok']);
+
+    $this->requestFactory->shouldReceive('createRequest')
+        ->once()
+        ->with('POST', $this->apiEndpoint . '/measure/event')
+        ->andReturn($this->request);
+
+    $this->request->shouldReceive('withHeader')->andReturn($this->request);
+    $this->streamFactory->shouldReceive('createStream')->once()->andReturn($this->stream);
+    $this->request->shouldReceive('withBody')->once()->andReturn($this->request);
+    $this->httpClient->shouldReceive('sendRequest')->once()->andReturn($this->response);
+
+    $this->response->shouldReceive('getBody')->once()->andReturn($this->stream);
+    $this->response->shouldReceive('getStatusCode')->once()->andReturn(200);
+    $this->stream->shouldReceive('__toString')->once()->andReturn($responseJson);
+
+    $result = $this->measure->trackEvent($event);
+
+    expect($result)->toBe(['status' => 'ok']);
+});
+
+test('Measure::trackBatch posts to /measure/batch', function () {
+    $events = [
+        [
+            'event_name' => 'search_completed',
+            'properties' => ['searchcraft_index_names' => ['products']],
+            'user' => ['user_id' => 'user-1'],
+        ],
+        [
+            'event_name' => 'api_summary_requested',
+            'properties' => [
+                'searchcraft_index_names' => ['products'],
+                'ai_provider' => 'anthropic',
+            ],
+            'user' => ['user_id' => 'user-1'],
+        ],
+    ];
+
+    $responseJson = json_encode(['status' => 'ok']);
+
+    $this->requestFactory->shouldReceive('createRequest')
+        ->once()
+        ->with('POST', $this->apiEndpoint . '/measure/batch')
+        ->andReturn($this->request);
+
+    $this->request->shouldReceive('withHeader')->andReturn($this->request);
+    $this->streamFactory->shouldReceive('createStream')->once()->andReturn($this->stream);
+    $this->request->shouldReceive('withBody')->once()->andReturn($this->request);
+    $this->httpClient->shouldReceive('sendRequest')->once()->andReturn($this->response);
+
+    $this->response->shouldReceive('getBody')->once()->andReturn($this->stream);
+    $this->response->shouldReceive('getStatusCode')->once()->andReturn(200);
+    $this->stream->shouldReceive('__toString')->once()->andReturn($responseJson);
+
+    $result = $this->measure->trackBatch($events);
+
+    expect($result)->toBe(['status' => 'ok']);
+});
+
+test('Measure::getDashboardSummary forwards filters as query string', function () {
+    $filters = [
+        'organization_id' => '4',
+        'date_start' => '2026-01-01',
+        'date_end' => '2026-04-01',
+        // Unknown keys should be dropped before the request is built.
+        'bogus' => 'ignored',
+    ];
+
+    $expectedQuery = http_build_query([
+        'organization_id' => '4',
+        'date_start' => '2026-01-01',
+        'date_end' => '2026-04-01',
+    ]);
+    $expectedUrl = $this->apiEndpoint . '/measure/dashboard/summary?' . $expectedQuery;
+
+    $responseJson = json_encode(['totals' => []]);
+
+    $this->requestFactory->shouldReceive('createRequest')
+        ->once()
+        ->with('GET', $expectedUrl)
+        ->andReturn($this->request);
+
+    $this->request->shouldReceive('withHeader')->andReturn($this->request);
+    $this->httpClient->shouldReceive('sendRequest')->once()->andReturn($this->response);
+
+    $this->response->shouldReceive('getBody')->once()->andReturn($this->stream);
+    $this->response->shouldReceive('getStatusCode')->once()->andReturn(200);
+    $this->stream->shouldReceive('__toString')->once()->andReturn($responseJson);
+
+    $result = $this->measure->getDashboardSummary($filters);
+
+    expect($result)->toBe(['totals' => []]);
+});
+
+test('Measure::getDashboardConversion sends empty query when no filters given', function () {
+    $responseJson = json_encode(['rows' => []]);
+
+    $this->requestFactory->shouldReceive('createRequest')
+        ->once()
+        ->with('GET', $this->apiEndpoint . '/measure/dashboard/conversion')
+        ->andReturn($this->request);
+
+    $this->request->shouldReceive('withHeader')->andReturn($this->request);
+    $this->httpClient->shouldReceive('sendRequest')->once()->andReturn($this->response);
+
+    $this->response->shouldReceive('getBody')->once()->andReturn($this->stream);
+    $this->response->shouldReceive('getStatusCode')->once()->andReturn(200);
+    $this->stream->shouldReceive('__toString')->once()->andReturn($responseJson);
+
+    $result = $this->measure->getDashboardConversion();
+
+    expect($result)->toBe(['rows' => []]);
+});
+
+test('Measure::getDashboardUsage forwards filters as query string', function () {
+    $filters = [
+        'application_id' => '9',
+        'granularity' => 'day',
+        'rpp' => 50,
+        'page' => 1,
+    ];
+
+    $expectedQuery = http_build_query($filters);
+    $expectedUrl = $this->apiEndpoint . '/measure/dashboard/usage?' . $expectedQuery;
+
+    $responseJson = json_encode(['rows' => []]);
+
+    $this->requestFactory->shouldReceive('createRequest')
+        ->once()
+        ->with('GET', $expectedUrl)
+        ->andReturn($this->request);
+
+    $this->request->shouldReceive('withHeader')->andReturn($this->request);
+    $this->httpClient->shouldReceive('sendRequest')->once()->andReturn($this->response);
+
+    $this->response->shouldReceive('getBody')->once()->andReturn($this->stream);
+    $this->response->shouldReceive('getStatusCode')->once()->andReturn(200);
+    $this->stream->shouldReceive('__toString')->once()->andReturn($responseJson);
+
+    $result = $this->measure->getDashboardUsage($filters);
+
+    expect($result)->toBe(['rows' => []]);
+});

--- a/tests/Api/SearchTest.php
+++ b/tests/Api/SearchTest.php
@@ -284,6 +284,124 @@ test('Search::federatedQuery with complex query', function () {
     expect($result)->toBe($responseData);
 });
 
+test('Search::searchSummary parses SSE events and invokes callback', function () {
+    $indexName = 'products';
+    $query = 'smartphone';
+    $options = ['limit' => 5, 'mode' => 'fuzzy'];
+
+    $sseBody = implode('', [
+        "event: metadata\ndata: {\"results_count\":2,\"cached\":false}\n\n",
+        "event: delta\ndata: {\"content\":\"Hello \"}\n\n",
+        "event: delta\ndata: {\"content\":\"world\"}\n\n",
+        "event: done\ndata: {\"results_count\":2}\n\n",
+    ]);
+
+    $this->requestFactory->shouldReceive('createRequest')
+        ->once()
+        ->with('POST', $this->apiEndpoint . "/index/{$indexName}/search/summary")
+        ->andReturn($this->request);
+
+    $this->request->shouldReceive('withHeader')
+        ->andReturn($this->request);
+
+    $this->streamFactory->shouldReceive('createStream')
+        ->once()
+        ->andReturn($this->stream);
+
+    $this->request->shouldReceive('withBody')
+        ->once()
+        ->andReturn($this->request);
+
+    $this->httpClient->shouldReceive('sendRequest')
+        ->once()
+        ->with($this->request)
+        ->andReturn($this->response);
+
+    $this->response->shouldReceive('getStatusCode')
+        ->once()
+        ->andReturn(200);
+
+    $this->response->shouldReceive('getBody')
+        ->once()
+        ->andReturn($this->stream);
+
+    $this->stream->shouldReceive('rewind')->andReturnNull();
+    $this->stream->shouldReceive('eof')
+        ->andReturnValues([false, true]);
+    $this->stream->shouldReceive('read')
+        ->once()
+        ->with(8192)
+        ->andReturn($sseBody);
+
+    $captured = [];
+    $result = $this->search->searchSummary(
+        $indexName,
+        $query,
+        $options,
+        function (string $event, $data) use (&$captured) {
+            $captured[] = [$event, $data];
+        }
+    );
+
+    expect($result)->toBe([
+        ['event' => 'metadata', 'data' => ['results_count' => 2, 'cached' => false]],
+        ['event' => 'delta', 'data' => ['content' => 'Hello ']],
+        ['event' => 'delta', 'data' => ['content' => 'world']],
+        ['event' => 'done', 'data' => ['results_count' => 2]],
+    ]);
+    expect($captured)->toHaveCount(4);
+    expect($captured[0])->toBe(['metadata', ['results_count' => 2, 'cached' => false]]);
+    expect($captured[2])->toBe(['delta', ['content' => 'world']]);
+});
+
+test('Search::searchSummary throws on API error response', function () {
+    $indexName = 'products';
+    $query = 'smartphone';
+
+    $errorJson = json_encode([
+        'error' => [
+            'message' => 'AI features are disabled for this index',
+            'code' => 400,
+        ],
+    ]);
+
+    $this->requestFactory->shouldReceive('createRequest')
+        ->once()
+        ->with('POST', $this->apiEndpoint . "/index/{$indexName}/search/summary")
+        ->andReturn($this->request);
+
+    $this->request->shouldReceive('withHeader')
+        ->andReturn($this->request);
+
+    $this->streamFactory->shouldReceive('createStream')
+        ->once()
+        ->andReturn($this->stream);
+
+    $this->request->shouldReceive('withBody')
+        ->once()
+        ->andReturn($this->request);
+
+    $this->httpClient->shouldReceive('sendRequest')
+        ->once()
+        ->with($this->request)
+        ->andReturn($this->response);
+
+    $this->response->shouldReceive('getStatusCode')
+        ->once()
+        ->andReturn(400);
+
+    $this->response->shouldReceive('getBody')
+        ->once()
+        ->andReturn($this->stream);
+
+    $this->stream->shouldReceive('__toString')
+        ->once()
+        ->andReturn($errorJson);
+
+    expect(fn() => $this->search->searchSummary($indexName, $query))
+        ->toThrow(SearchcraftException::class, 'AI features are disabled for this index');
+});
+
 test('Search::query handles API error', function () {
     $indexName = 'test-index';
     $query = 'test query';

--- a/tests/Api/StopwordsTest.php
+++ b/tests/Api/StopwordsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;

--- a/tests/Api/SynonymsTest.php
+++ b/tests/Api/SynonymsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -69,7 +70,10 @@ test('Synonyms::addSynonyms', function () {
     $indexName = 'test-index';
     $synonyms = [['hot', 'warm'], ['cold', 'cool', 'chilly']];
 
-    $responseData = ['added' => 2, 'synonyms' => [['big', 'large'], ['small', 'tiny'], ['hot', 'warm'], ['cold', 'cool', 'chilly']]];
+    $responseData = [
+        'added' => 2,
+        'synonyms' => [['big', 'large'], ['small', 'tiny'], ['hot', 'warm'], ['cold', 'cool', 'chilly']],
+    ];
     $responseJson = json_encode($responseData);
 
     $this->requestFactory->shouldReceive('createRequest')

--- a/tests/Api/TransactionTest.php
+++ b/tests/Api/TransactionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Searchcraft\Exception\SearchcraftException;
 
 test('SearchcraftException::constructor', function () {
@@ -61,5 +62,3 @@ test('SearchcraftException::fromApiResponse with unknown error format', function
     // The test should now expect the wrapped array format:
     expect($exception->getErrorData())->toBe(['__original_error' => $responseData['error']]);
 });
-
-

--- a/tests/Helpers/ChunkedStreamStub.php
+++ b/tests/Helpers/ChunkedStreamStub.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Searchcraft\Tests\Helpers;
+
+/**
+ * Minimal in-memory StreamInterface-ish stub that yields chunks from a list.
+ *
+ * Used by parser tests to simulate a PSR-7 stream delivering SSE bytes in
+ * arbitrary pieces. Only implements the handful of methods that
+ * Searchcraft\Api\Base::parseEventStream actually calls: rewind(), eof(),
+ * read().
+ */
+class ChunkedStreamStub
+{
+    /**
+     * @var string[]
+     */
+    private $chunks;
+
+    /**
+     * @var int
+     */
+    private $cursor = 0;
+
+    /**
+     * @param string[] $chunks Ordered list of chunks to yield on successive
+     *                         read() calls. Each entry is returned as a
+     *                         single read result, regardless of length.
+     */
+    public function __construct(array $chunks)
+    {
+        $this->chunks = array_values($chunks);
+    }
+
+    /**
+     * Rewind the cursor to the start of the chunk list.
+     *
+     * @return void
+     */
+    public function rewind(): void
+    {
+        $this->cursor = 0;
+    }
+
+    /**
+     * Whether every chunk has been consumed.
+     *
+     * @return bool
+     */
+    public function eof(): bool
+    {
+        return $this->cursor >= count($this->chunks);
+    }
+
+    /**
+     * Return the next chunk and advance the cursor.
+     *
+     * @param int $_length Unused; accepted for PSR-7 compatibility. Each
+     *                     call returns the full next chunk.
+     * @return string
+     */
+    public function read($_length): string
+    {
+        if ($this->eof()) {
+            return '';
+        }
+        return $this->chunks[$this->cursor++];
+    }
+}

--- a/tests/Helpers/TestApi.php
+++ b/tests/Helpers/TestApi.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Searchcraft\Tests\Helpers;
+
+use Searchcraft\Api\Base;
+
+/**
+ * Concrete subclass of the abstract Searchcraft\Api\Base class used to
+ * exercise its protected `request()` and `parseEventStream()` helpers
+ * from Pest tests.
+ */
+class TestApi extends Base
+{
+    /**
+     * Expose Base::request() for direct testing.
+     *
+     * @param string $method HTTP method.
+     * @param string $path API path.
+     * @param array $params Request parameters forwarded to Base::request().
+     * @param array $headers Additional headers forwarded to Base::request().
+     * @return array Decoded JSON response from the mocked HTTP client.
+     */
+    public function testRequest(string $method, string $path, array $params = [], array $headers = []): array
+    {
+        return $this->request($method, $path, $params, $headers);
+    }
+
+    /**
+     * Expose Base::parseEventStream() for direct testing.
+     *
+     * @param object $stream Stream-like object whose `eof()`, `read()`,
+     *                       and optional `rewind()` methods are used to
+     *                       supply bytes to the parser.
+     * @param callable|null $onEvent Optional per-event callback forwarded
+     *                               to parseEventStream().
+     * @return array List of parsed SSE events.
+     */
+    public function testParseEventStream($stream, ?callable $onEvent = null): array
+    {
+        return $this->parseEventStream($stream, $onEvent);
+    }
+}

--- a/tests/SearchcraftTest.php
+++ b/tests/SearchcraftTest.php
@@ -10,6 +10,7 @@ use Searchcraft\Api\Documents;
 use Searchcraft\Api\Federation;
 use Searchcraft\Api\Healthcheck;
 use Searchcraft\Api\Index;
+use Searchcraft\Api\Measure;
 use Searchcraft\Api\Search;
 use Searchcraft\Api\Stopwords;
 use Searchcraft\Api\Synonyms;
@@ -195,6 +196,18 @@ test('Searchcraft::synonyms returns Synonyms instance', function () {
         $this->streamFactory
     );
     expect($searchcraft->synonyms())->toBeInstanceOf(Synonyms::class);
+});
+
+test('Searchcraft::measure returns Measure instance', function () {
+    $searchcraft = new Searchcraft(
+        $this->apiKey,
+        Searchcraft::KEY_TYPE_ADMIN,
+        null,
+        $this->httpClient,
+        $this->requestFactory,
+        $this->streamFactory
+    );
+    expect($searchcraft->measure())->toBeInstanceOf(Measure::class);
 });
 
 test('Searchcraft::transactions returns Transactions instance', function () {

--- a/tests/ValidatorsTest.php
+++ b/tests/ValidatorsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Searchcraft\Exception\SearchcraftException;
+use Searchcraft\Validators;
+
+test('Validators::validateLimit accepts values 1 through MAX_SEARCH_LIMIT', function () {
+    Validators::validateLimit(1);
+    Validators::validateLimit(50);
+    Validators::validateLimit(Validators::MAX_SEARCH_LIMIT);
+    expect(true)->toBeTrue();
+});
+
+test('Validators::validateLimit rejects zero', function () {
+    expect(fn () => Validators::validateLimit(0))
+        ->toThrow(SearchcraftException::class, 'limit must be a positive integer');
+});
+
+test('Validators::validateLimit rejects negative values', function () {
+    expect(fn () => Validators::validateLimit(-1))
+        ->toThrow(SearchcraftException::class, 'limit must be a positive integer');
+});
+
+test('Validators::validateLimit rejects values above the engine cap', function () {
+    expect(fn () => Validators::validateLimit(Validators::MAX_SEARCH_LIMIT + 1))
+        ->toThrow(SearchcraftException::class, 'limit cannot exceed 200');
+});
+
+test('Validators::validateLimit rejects non-integers', function () {
+    expect(fn () => Validators::validateLimit('10'))
+        ->toThrow(SearchcraftException::class, 'limit must be a positive integer');
+
+    expect(fn () => Validators::validateLimit(10.5))
+        ->toThrow(SearchcraftException::class, 'limit must be a positive integer');
+});
+
+test('Validators::validateOffset accepts zero and positive integers', function () {
+    Validators::validateOffset(0);
+    Validators::validateOffset(100);
+    expect(true)->toBeTrue();
+});
+
+test('Validators::validateOffset rejects negative values', function () {
+    expect(fn () => Validators::validateOffset(-1))
+        ->toThrow(SearchcraftException::class, 'offset must be a non-negative integer');
+});
+
+test('Validators::validateOffset rejects non-integers', function () {
+    expect(fn () => Validators::validateOffset('5'))
+        ->toThrow(SearchcraftException::class, 'offset must be a non-negative integer');
+});
+
+test('Search::query rejects over-limit limits before making the request', function () {
+    $searchcraft = new \Searchcraft\Searchcraft(
+        'test-key',
+        \Searchcraft\Searchcraft::KEY_TYPE_ADMIN,
+        null,
+        Mockery::mock(\Psr\Http\Client\ClientInterface::class),
+        Mockery::mock(\Psr\Http\Message\RequestFactoryInterface::class),
+        Mockery::mock(\Psr\Http\Message\StreamFactoryInterface::class)
+    );
+
+    expect(fn () => $searchcraft->search()->query('products', 'foo', ['limit' => 500]))
+        ->toThrow(SearchcraftException::class, 'limit cannot exceed 200');
+
+    Mockery::close();
+});


### PR DESCRIPTION
Release 0.8.0 of the Searchcraft API PHP Client.
Adds compatibility with Core version 0.10.0.

- New: `Index::getCapabilities()` wraps `GET /index/:index/capabilities` and
  returns the index's AI capability flags (`enabled`,
  `searchSummaryConfigured`, `llmProviderConfigured`, `llmModelConfigured`).
- New: `Search::searchSummary()` wraps `POST /index/:index/search/summary`,
  parses the Server-Sent Events stream, and returns the tagged `metadata`,
  `delta`, `done`, and `error` events. A callback may be supplied to react
  to events as they arrive.
- New: `Authentication::getIndexKeys()` wraps `GET /auth/index/:index_name`.
- New: `Measure` API — wrapper for analytic events
  (`trackEvent`, `trackBatch`) and dashboard reporting
  (`getDashboardSummary`, `getDashboardConversion`, `getDashboardUsage`).
- New: `Searchcraft\Validators` helper with `validateLimit` and
  `validateOffset`. `Search::query`, `Search::federatedQuery`, and
  `Search::searchSummary` now fail fast on invalid pagination before
  issuing a request.
- Doc: `Index::patchIndex()` docblock now notes that PATCH supports
  top-level `ai` and `ai_enabled` updates (changing `ai_enabled` requires
  an admin-level key).
- Fix: `Base::request()` previously appended the query string to a local
  variable when building GET requests but never rebuilt the PSR-7
  request, so GET query parameters were silently dropped. The request is
  now created once with the fully-qualified URL.